### PR TITLE
`fix link for quotes.js`

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -118,7 +118,7 @@
     </pre>
     
     <h2 id="contributing">Contributing</h2>
-    <p>If you want to add some quotes, just add them in <a href="https://github.com/shadowoff09/lucifer-quotes/blob/main/quotes.js">quotes.js</a> file and do a pull request !</p>
+    <p>If you want to add some quotes, just add them in <a href="https://github.com/shadowoff09/lucifer-quotes/blob/main/src/quotes.js">quotes.js</a> file and do a pull request !</p>
     <h2 id="authors">Authors</h2>
     <ul>
       <li><a href="https://www.github.com/shadowoff09">@shadowoff09</a></li>


### PR DESCRIPTION
Add correct link for `quotes.js` in index.html file on line number 120.

```html
 <h2 id="contributing">Contributing</h2>
 <p>If you want to add some quotes, just add them in <a href="https://github.com/shadowoff09/lucifer-quotes/blob/main/src/quotes.js">quotes.js</a> file and do a pull request !</p>
```

